### PR TITLE
Fix an issue that equal numbers will be discarded in metrics hash table

### DIFF
--- a/Swiftstraints/VisualFormatLanguage.swift
+++ b/Swiftstraints/VisualFormatLanguage.swift
@@ -16,7 +16,7 @@ private func vflKey(_ object: AnyObject) -> String {
 public struct VisualFormatLanguage : ExpressibleByStringInterpolation {
     
     let format: String
-    var metrics = NSHashTable<NSNumber>(options: NSPointerFunctions.Options.copyIn)
+    var metrics = NSHashTable<NSNumber>(options: [.copyIn, .objectPointerPersonality])
     var views = NSHashTable<UIView>(options: NSPointerFunctions.Options.weakMemory)
     var viewCount: Int = 0  // used to check if this VFL is still valid; since views won't persist the view pointers, if the view is deallocated, there will be an exception when constraints are created later
     


### PR DESCRIPTION
Sorry I made a mistake when changing the hash table's options. Since the “redundant” (for Swift 3.1) init methods are removed, the numbers are fetched and stored in a different way. "Weak" cannot be used, moreover, numbers of equal values should not be treated as the same, either.

I've added .objectPointerPersonality to solve this crash.

Case:
`H:|-(\(number1))-[\(view)]-(\(number2))-|`, in which number1 is equal to number2, e.g. both are 15.