### PR TITLE
Fixed init(H: VFLComponent, options: NSLayoutConstraint.FormatOptions = []) and init(V: VFLComponent, options: NSLayoutConstraint.FormatOptions = [])

### DIFF
--- a/Swiftstraints/VFLComponent.swift
+++ b/Swiftstraints/VFLComponent.swift
@@ -205,11 +205,11 @@ public func .~(dimension: VFLComponent, priority: LayoutPriority) -> VFLComponen
 /// NSLayoutConstraints(H:|-30-[versionLabel:==3.~(.high)]-10-[logoView:>=5]-30-|)
 /// NSLayoutConstraints(V:|-30-[versionLabel:20]-10-[logoView]-(30.~(.required - 1))-|)
 
-extension Array where Element: NSLayoutConstraint {
+extension Array where Element == NSLayoutConstraint {
     public init(H: VFLComponent, options: NSLayoutConstraint.FormatOptions = []) {
-        self = H.constraints(axis: .horizontal, options: options) as! [Element]
+        self = H.constraints(axis: .horizontal, options: options)
     }
     public init(V: VFLComponent, options: NSLayoutConstraint.FormatOptions = []) {
-        self = V.constraints(axis: .vertical, options: options) as! [Element]
+        self = V.constraints(axis: .vertical, options: options)
     }
 }


### PR DESCRIPTION
Hello.
Thank you for Swiftstraints.
In this pull request I fixed the problem with the Array elements type create with `init(H: VFLComponent, options: NSLayoutConstraint.FormatOptions = [])` and `init(V: VFLComponent, options: NSLayoutConstraint.FormatOptions = [])`. Currently the following test fails:

```
func testVFLComponent2() {
    class MyConstraint: NSLayoutConstraint {
            
    }
        
    let superview = UIView()
    let view1 = UIView()
    let view2 = UIView()
    superview.addSubview(view1)
    superview.addSubview(view2)

    _ = {
        let shorthandConstraints = [MyConstraint](H:|-[view1]-(>=5)-[view2]-3-|)
        let normalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|-[view1]-(>=5)-[view2]-3-|",
                                                               options: [],
                                                               metrics: nil,
                                                               views: ["view1" : view1, "view2" : view2])
        for (lh, rh) in zip(shorthandConstraints, normalConstraints) {
            XCTAssert(lh == rh)
        }
    }()
}
```